### PR TITLE
Else and Else If snippets

### DIFF
--- a/snippet/sourcepawn.else-..-(else).sublime-snippet
+++ b/snippet/sourcepawn.else-..-(else).sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+	<description>Else</description>
+    <content><![CDATA[else
+{
+	${1:/* code */}
+}]]></content>
+    <tabTrigger>else</tabTrigger>
+    <scope>source.sp, source.inc</scope>
+</snippet>

--- a/snippet/sourcepawn.else-if-..-(else).sublime-snippet
+++ b/snippet/sourcepawn.else-if-..-(else).sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+	<description>Else If Condition</description>
+    <content><![CDATA[else if (${1:/* condition */})
+{
+	${0:/* code */}
+}]]></content>
+    <tabTrigger>elseif</tabTrigger>
+    <scope>source.sp, source.inc</scope>
+</snippet>


### PR DESCRIPTION
I am added those snippets to prevent replacing `else` on pressing `<enter>` key to one of _functions from includes_ snippet.
![else](https://f.cloud.github.com/assets/3440832/148318/074ffc92-74fd-11e2-8a6d-2bc004bebe94.png)

With these snippets Sublime works correctly:
![else2](https://f.cloud.github.com/assets/3440832/148328/bee918b6-74fd-11e2-8dd0-2a74ee1ac45e.png)
-->
![else3](https://f.cloud.github.com/assets/3440832/148329/c0f90aa8-74fd-11e2-8b7a-533c4a6bc163.png)
